### PR TITLE
fix contact email address

### DIFF
--- a/vast-v1.en.md
+++ b/vast-v1.en.md
@@ -6,7 +6,7 @@ See [Digital Video Ad Serving Template (VAST) 3.0](https://www.iab.com/guideline
 
 ### Attention
 
-This specification may be incomplete. If you find any inadequacy or encounter confusion, please contact the person in charge: [fluct_dev@voyagegroup.info](mailto:fluct_dev@voyagegroup.info).
+This specification may be incomplete. If you find any inadequacy or encounter confusion, please contact the person in charge: [developer@fluct.jp](mailto:developer@fluct.jp).
 
 Moreover, this specification does not contain description of general VAST protocol.
 

--- a/vast-v1.md
+++ b/vast-v1.md
@@ -4,7 +4,7 @@
 
 注意
 
-この仕様書には不完全な点があるかもしれません。不備や不明瞭な点がありましたら、担当者か [fluct_dev@voyagegroup.info](mailto:fluct_dev@voyagegroup.info) に教えてください。また、一般的なRTBのプロトコルそのものに対する説明はありません。
+この仕様書には不完全な点があるかもしれません。不備や不明瞭な点がありましたら、担当者か [developer@fluct.jp](mailto:developer@fluct.jp) に教えてください。また、一般的なRTBのプロトコルそのものに対する説明はありません。
 
 
 ## Table of Contents

--- a/version2.en.md
+++ b/version2.en.md
@@ -6,7 +6,7 @@ See [IAB OpenRTB API Specification Version 2.5](https://www.iab.com/wp-content/u
 
 ### Attention
 
-This specification may be incomplete. If you find any inadequacy or encounter confusion, please contact the person in charge: [fluct_dev@voyagegroup.info](mailto:fluct_dev@voyagegroup.info).
+This specification may be incomplete. If you find any inadequacy or encounter confusion, please contact the person in charge: [developer@fluct.jp](mailto:developer@fluct.jp).
 
 Moreover, this specification does not contain description of general RTB protocol (e.g., OpenRTB).
 

--- a/version2.md
+++ b/version2.md
@@ -4,7 +4,7 @@ OpenRTB 2.5 に準拠しています。詳細は[IABのOpenRTB API Specification
 
 注意
 
-この仕様書には不完全な点があるかもしれません。不備や不明瞭な点がありましたら、担当者か [fluct_dev@voyagegroup.info](mailto:fluct_dev@voyagegroup.info) に教えてください。また、一般的なRTBのプロトコルそのものに対する説明はありません。
+この仕様書には不完全な点があるかもしれません。不備や不明瞭な点がありましたら、担当者か [developer@fluct.jp](mailto:developer@fluct.jp) に教えてください。また、一般的なRTBのプロトコルそのものに対する説明はありません。
 
 
 ## Table of Contents


### PR DESCRIPTION
### What
連絡先として記載されているメールアドレスを developer@fluct.jp (Google Group) に変更
* developer@fluct.jp -> fluct_g_developer@voyagegroup.com に転送される

### Why
QuickML (@voyagegroup.info で終わるメールアドレス) は 全社的に使用が非推奨となっているため、なくしていきたい

### Related Issues
* Backlog: https://ecnstaff.backlog.jp/view/FLUCT_SSP-10854
* Kibela: https://voyagegroup.kibe.la/notes/2676, https://voyagegroup.kibe.la/notes/4553
* Trello Card: https://trello.com/c/J1auHKUY