### PR TITLE
Update 2020-08-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 変更履歴
 
 * 2.2
+    * 2020/08/31
+        * MoPub iOS 14 Support Proposal Click Tracking に対応
+            * Bid Response Bid Object
+                * `ext.clicktrackers` 追加
+            * Bid Response 例を更新
     * 2020/08/27
         * MoPub iOS 14 Support Proposal に対応
             * Bid Request SKAdn Request Object を仕様に追加

--- a/version2.en.md
+++ b/version2.en.md
@@ -1120,6 +1120,11 @@ HTTP 204 No Content is expected for no bid.
     <td>skadn Response object</td>
     <td>MoPub iOS 14 support proposal response object</td>
   </tr>
+  <tr>
+    <td>ext.clicktrackers</td>
+    <td>array of strings</td>
+    <td>Click trackers for MoPub iOS 14 support proposal</td>
+  </tr>
 </table>
 
 #### skadn Response Object

--- a/version2.ja.md
+++ b/version2.ja.md
@@ -1214,6 +1214,11 @@ DSPはJSONフォーマットで入札情報をシリアライズします。
     <td>skadn Response object</td>
     <td>MoPub iOS 14 サポート提案に関する情報</td>
   </tr>
+  <tr>
+    <td>ext.clicktrackers</td>
+    <td>array of strings</td>
+    <td>MoPub iOS 14 サポート提案のclicktrackers</td>
+  </tr>
 </table>
 
 #### skadn Response Object

--- a/version2.res-examples.md
+++ b/version2.res-examples.md
@@ -244,7 +244,10 @@
               "sourceapp": "123456789",
               "timestamp": "1594406341",
               "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg=="
-            }
+            },
+            "clicktrackers": [
+                "https://tracker.example.com/click?id=57750EF0-3125-49FF-89AA-0B6A398B21FA"
+            ]
           }
         }
       ]


### PR DESCRIPTION
* MoPub iOS 14 Support Proposal Click Tracking に対応
    * Bid Response Bid Object
        * `ext.clicktrackers` 追加
        * Bid Response 例を更新